### PR TITLE
joblib 1.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 


### PR DESCRIPTION
Update joblib to 1.1.0

Category:  anaconda | subcategory:   | pkg_type:  python
Popularity:  5752248 downloads -  joblib  1.1.0  Lightweight pipelining: using Python functions as pipeline jobs.
Version change: bump version number from 1.0.1 to 1.1.0
  license: BSD-3-Clause
Release date:  Oct 7, 2021
Bug Tracker: new open issues https://github.com/joblib/joblib/issues
Github changelog:  https://github.com/joblib/joblib/blob/master/CHANGES.rst
Upstream license: https://github.com/joblib/joblib/blob/master/LICENSE.txt
Upstream setup file: https://github.com/joblib/joblib/blob/1.1.0/setup.py

The package joblib is mentioned inside the packages:
nltk | orange3 | pandas-profiling | phik | pomegranate | pynndescent | scikit-learn | threadpoolctl |

Actions:
1. Update python
2. Add missing dependencies
3. Add python <3.10 to the test/requires
4. Update test/imports
5. Update home url
6. Add doc, dev urls
7. Add license_family
8. Add pytest to the test/requires

Result:
- all-succeeded
