### PR TITLE
update 1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.1.1" %}
+{% set version = "1.2.0" %}
 
 package:
   name: joblib
@@ -6,12 +6,12 @@ package:
 
 source:
   url: https://github.com/joblib/joblib/archive/{{ version }}.tar.gz
-  sha256: 34c7b4c5fc5b6ba65982dca55daceaa371a9003d8da7fe0f952e076e07e53910
+  sha256: 574eca5aaeb0a06c4fe0a8e8e67b24715218fb0f9d0fdc9d4f30519100885e53
 
 build:
   number: 0
-  skip: True  # [py<37]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True  # [py<37 or s390x]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,10 +49,8 @@ about:
     large data in particular and has specific optimizations for numpy arrays."
   license: BSD-3-Clause
   license_family: BSD
-  license_file: LICENSE.txt
   license_url: https://github.com/joblib/joblib/blob/{{ version }}/LICENSE.txt
   doc_url: https://joblib.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/joblib/joblib/tree/{{ version }}/doc
   dev_url: https://github.com/joblib/joblib
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - joblib.externals.loky.backend
 
 about:
-  home: https://joblib.readthedocs.io/en/latest/
+  home: https://joblib.readthedocs.io/
   summary: 'Lightweight pipelining: using Python functions as pipeline jobs.'
   description: |
     "A set of tools to provide lightweight pipelining in Python. In particular:
@@ -50,7 +50,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_url: https://github.com/joblib/joblib/blob/{{ version }}/LICENSE.txt
-  doc_url: https://joblib.readthedocs.io/en/latest/
+  doc_url: https://joblib.readthedocs.io/
   dev_url: https://github.com/joblib/joblib
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<37 or s390x]
+  skip: True  # [py<37]
 
 requirements:
   host:


### PR DESCRIPTION
## Joblib 1.2.0 Update
[Jira Ticket](https://anaconda.atlassian.net/browse/PKG-2044)
[Upstream](https://github.com/joblib/joblib)
[Dependencies ](https://github.com/joblib/joblib/blob/master/pyproject.toml)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies