### PR TITLE
joblib 1.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.0" %}
+{% set version = "1.4.2" %}
 
 package:
   name: joblib
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/joblib/joblib/archive/{{ version }}.tar.gz
-  sha256: da0b0297c5578ced1a9ad8bad44f8d6ab847401c6707dc7b8c62a4c27d9e4516
+  sha256: 1d95f5f3ab303be89aa4666956bf05a589f56e52c29b836267c8e3885223ff90
 
 build:
   number: 0
@@ -21,7 +21,6 @@ requirements:
     - wheel
   run:
     - python
-    # Optional dependencies are numpy, python-lz4, psutil
 
 test:
   requires:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4935](https://anaconda.atlassian.net/browse/PKG-4935)
- [Upstream repository](https://github.com/joblib/joblib/tree/1.4.2)
- [Upstream changelog/diff](https://github.com/joblib/joblib/blob/1.4.2/CHANGES.rst)

### Explanation of changes:

- Bump version and set sha256


[PKG-4935]: https://anaconda.atlassian.net/browse/PKG-4935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ